### PR TITLE
Update directions for locating the "import" page.

### DIFF
--- a/index.php
+++ b/index.php
@@ -572,7 +572,7 @@ header("content-disposition: attachment; filename=tumblr_$username.xml");
 
 <!-- To import this information into a WordPress blog follow these steps. -->
 <!-- 1. Log into that blog as an administrator. -->
-<!-- 2. Go to Manage: Import in the blog's admin panels. -->
+<!-- 2. Go to Tools: Import in the blog's dashboard. -->
 <!-- 3. Choose "WordPress" from the list. -->
 <!-- 4. Upload this file using the form provided on that page. -->
 <!-- 5. You will first be asked to map the authors in this export file to users -->


### PR DESCRIPTION
The import option is now under Tools in the dashboard (on both WP.com and self-hosted WP).

P.S. Thanks for this awesome tool, it worked like a charm! :)
